### PR TITLE
Update Job Status List

### DIFF
--- a/templates/aml-cli-v2/run-pipeline.yml
+++ b/templates/aml-cli-v2/run-pipeline.yml
@@ -25,15 +25,15 @@ steps:
           echo "Status query failed"
           exit 4
         fi
-        running=("Queued" "Starting" "Preparing" "Running" "Finalizing")
+        running=("NotStarted" "Queued" "Starting" "Preparing" "Running" "Finalizing" "CancelRequested")
         while [[ ${running[*]} =~ $status ]]
         do
           sleep 15 
           status=$(az ml job show -n $run_id --query status -o tsv)
           echo $status
         done
-        if [[ "$status" = "Failed" ]]  
+        if [[ "$status" != "Completed" ]]  
         then
-          echo "Training Job failed"
+          echo "Training Job failed or canceled"
           exit 3
         fi


### PR DESCRIPTION
1). NotStarted is a common state in the beginning of the job
2). Canceled should be triggered as well. Devs/DSs cancel their jobs often during development. So, CancelRequested and Canceled were added.
3). All the statuses rather than Completed (including Pausing, Paused, Unapproved etc) should generate fails of the DevOps pipeline