### PR TITLE
Upgrade az cli to >= 2.30.0 and azureml-sdk to 1.43.0

### DIFF
--- a/src/python-sdk/install_requirements.sh
+++ b/src/python-sdk/install_requirements.sh
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 python --version
-pip install azureml-sdk==1.36.0
+pip install azureml-sdk==1.43.0
 pip install pytest
 pip install pyyaml
 pip install azureml-dataset-runtime --upgrade

--- a/templates/python-sdk/install-az-cli.yml
+++ b/templates/python-sdk/install-az-cli.yml
@@ -11,4 +11,4 @@ steps:
       workingDirectory: code/
       inlineScript: |
         set -e # fail on error
-        python -m pip install -U --force-reinstall pip pip install azure-cli==2.29
+        python -m pip install -U --force-reinstall pip pip install azure-cli


### PR DESCRIPTION
Fixes #11 

Changes affect the SDK version only:
- Unpinned azure-cli 2.29 so versions >= 2.30 are installed from now on
- Pinned azureml-sdk to 1.43.0
