### PR TITLE
SDK - Include run ID in the data paths in pipeline definition

### DIFF
--- a/src/python-sdk/deploy_training_pipeline.py
+++ b/src/python-sdk/deploy_training_pipeline.py
@@ -1,16 +1,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import os
 import re
 import argparse
 import yaml
 import shlex
 
 import azureml.core
-from azureml.core import Workspace, Experiment, Datastore, Dataset, RunConfiguration, Environment
+from azureml.core import Workspace, Datastore, Dataset, RunConfiguration, Environment
 
-from azureml.core.compute import AmlCompute, ComputeTarget
 from azureml.pipeline.core import Pipeline, PipelineData, PipelineParameter
 from azureml.pipeline.steps import PythonScriptStep
 from azureml.data.dataset_consumption_config import DatasetConsumptionConfig
@@ -61,10 +59,11 @@ for arg in shlex.split(config['training_arguments']):
 print(f"Expanded arguments: {arguments}")
 print(training_dataset_consumption)
 
-prepared_data_path = OutputFileDatasetConfig(name="prepared_data", destination=(datastore, "pipeline_artifacts/prepared_data")).as_upload()
-trained_model_path = OutputFileDatasetConfig(name="trained_model", destination=(datastore, "pipeline_artifacts/trained_model")).as_upload()
-explainer_path = OutputFileDatasetConfig(name="explainer", destination=(datastore, "pipeline_artifacts/trained_model")).as_upload()
-evaluation_results_path = OutputFileDatasetConfig(name="evaluation_results", destination=(datastore, "pipeline_artifacts/evaluation_results")).as_upload()
+# Set up data connections between steps - {run-id} is automatically replaced with the corresponding ID during execution
+prepared_data_path = OutputFileDatasetConfig(name="prepared_data", destination=(datastore, "pipeline_artifacts/prepared_data/{run-id}/")).as_upload()
+trained_model_path = OutputFileDatasetConfig(name="trained_model", destination=(datastore, "pipeline_artifacts/trained_model/{run-id}/")).as_upload()
+explainer_path = OutputFileDatasetConfig(name="explainer", destination=(datastore, "pipeline_artifacts/trained_model/{run-id}/")).as_upload()
+evaluation_results_path = OutputFileDatasetConfig(name="evaluation_results", destination=(datastore, "pipeline_artifacts/evaluation_results/{run-id}/")).as_upload()
 deploy_flag = PipelineData("deploy_flag")
 
 

--- a/src/python-sdk/install_requirements.sh
+++ b/src/python-sdk/install_requirements.sh
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 python --version
-pip install azureml-sdk==1.36.0
+pip install azureml-sdk==1.43.0
 pip install pytest
 pip install pyyaml
 pip install azureml-dataset-runtime --upgrade

--- a/templates/python-sdk/install-az-cli.yml
+++ b/templates/python-sdk/install-az-cli.yml
@@ -11,4 +11,4 @@ steps:
       workingDirectory: code/
       inlineScript: |
         set -e # fail on error
-        python -m pip install -U --force-reinstall pip pip install azure-cli==2.29
+        python -m pip install -U --force-reinstall pip pip install azure-cli


### PR DESCRIPTION
Using the `{run-id}` placeholder ([docs](https://docs.microsoft.com/en-us/python/api/azureml-core/azureml.data.outputfiledatasetconfig?view=azure-ml-py#constructor)) to enforce the same path convention by design for all experiments.