### PR TITLE
GHA workflow wait for AzureML pipeline completion

### DIFF
--- a/.github/workflows/run-pipeline.yml
+++ b/.github/workflows/run-pipeline.yml
@@ -35,5 +35,29 @@ jobs:
         run: az extension update -n ml
       - name: run-ml-pipeline
         run: |
-          az ml job create --file ${{ github.workspace }}/${{ inputs.parameters-file  }} --resource-group ${{ inputs.resource_group }} \
-          --workspace-name ${{ inputs.workspace_name }} --query name -o tsv
+          run_id=$(az ml job create --file ${{ github.workspace }}/${{ inputs.parameters-file  }} --resource-group ${{ inputs.resource_group }} \
+          --workspace-name ${{ inputs.workspace_name }} --query name -o tsv)
+          if [[ -z "$run_id" ]]
+          then
+            echo "Job creation failed"
+            exit 3
+          fi
+          az ml job show -n $run_id --web
+          status=$(az ml job show -n $run_id --query status -o tsv)
+          if [[ -z "$status" ]]
+          then
+            echo "Status query failed"
+            exit 4
+          fi
+          running=("NotStarted" "Queued" "Starting" "Preparing" "Running" "Finalizing" "CancelRequested")
+          while [[ ${running[*]} =~ $status ]]
+          do
+            sleep 15 
+            status=$(az ml job show -n $run_id --query status -o tsv)
+            echo $status
+          done
+          if [[ "$status" != "Completed" ]]  
+          then
+            echo "Training Job failed or canceled"
+            exit 3
+          fi

--- a/.github/workflows/run-pipeline.yml
+++ b/.github/workflows/run-pipeline.yml
@@ -35,15 +35,14 @@ jobs:
         run: az extension update -n ml
       - name: run-ml-pipeline
         run: |
-          run_id=$(az ml job create --file ${{ github.workspace }}/${{ inputs.parameters-file  }} --resource-group ${{ inputs.resource_group }} \
-          --workspace-name ${{ inputs.workspace_name }} --query name -o tsv)
+          run_id=$(az ml job create --file ${{ github.workspace }}/${{ inputs.parameters-file  }} --resource-group ${{ inputs.resource_group }} --workspace-name ${{ inputs.workspace_name }} --query name -o tsv)
           if [[ -z "$run_id" ]]
           then
             echo "Job creation failed"
             exit 3
           fi
-          az ml job show -n $run_id --web
-          status=$(az ml job show -n $run_id --query status -o tsv)
+          az ml job show -n $run_id --resource-group ${{ inputs.resource_group }} --workspace-name ${{ inputs.workspace_name }} --web 
+          status=$(az ml job show -n $run_id --resource-group ${{ inputs.resource_group }} --workspace-name ${{ inputs.workspace_name }} --query status -o tsv)
           if [[ -z "$status" ]]
           then
             echo "Status query failed"
@@ -53,7 +52,7 @@ jobs:
           while [[ ${running[*]} =~ $status ]]
           do
             sleep 15 
-            status=$(az ml job show -n $run_id --query status -o tsv)
+            status=$(az ml job show -n $run_id --resource-group ${{ inputs.resource_group }} --workspace-name ${{ inputs.workspace_name }} --query status -o tsv)
             echo $status
           done
           if [[ "$status" != "Completed" ]]  


### PR DESCRIPTION
Added code to run-pipeline.yml for github workflows to wait until the submitted Azure ML pipeline job is complete before completing the workflow job. Previous run-pipeline.yml runs may submit a long-running Azure ML training job and immediately return as successful even if the Azure ML job later fails.

Job check and wait code borrowed from templates/aml-cli-v2/run-pipeline.yml for ADO and adapted to GH workflow.