### PR TITLE
Add validate endpoint step before creation

### DIFF
--- a/.github/workflows/create-endpoint.yml
+++ b/.github/workflows/create-endpoint.yml
@@ -38,17 +38,10 @@ jobs:
         run: az extension update -n ml
       - name: create-environment-from-file
         run: |
-          ENDPOINT_EXISTS=$(az ml ${{ inputs.endpoint_type}}-endpoint list -o tsv --query "[?name==${{ inputs.endpoint_name}}][name]" | wc -l)
-          echo $ENDPOINT_NAME $ENDPOINT_EXISTS
-          az ml ${{ inputs.endpoint_type}}-endpoint list -o tsv
-
-          if [[ ENDPOINT_EXISTS -ne 1 ]]; then
-          az ml ${{ inputs.endpoint_type}}-endpoint create --name ${{ inputs.endpoint_name}} -f ${{ inputs.endpoint_file }}
+          EP=$(az ml ${{ inputs.endpoint_type }}-endpoint list --query "[?name==${{ inputs.endpoint_name }}]"  -o tsv --resource-group ${{ inputs.resource_group }} --workspace-name ${{ inputs.workspace_name }})
+          if [[ EP -ne 1 ]]; then
+          echo "Endpoint not exists"
+          az ml ${{ inputs.endpoint_type }}-endpoint create --name ${{ inputs.endpoint_name }} -f ${{ github.workspace }}/${{ inputs.endpoint_file }} --resource-group ${{ inputs.resource_group }} --workspace-name ${{ inputs.workspace_name }} 
           else
           echo "Endpoint exists"
           fi
-      # - name: create-environment-from-file
-      #   run: |
-      #     az ml ${{ inputs.endpoint_type }}-endpoint create --name ${{ inputs.endpoint_name }} \
-      #     -f ${{ github.workspace }}/${{ inputs.endpoint_file }} --resource-group ${{ inputs.resource_group }} \
-      #     --workspace-name ${{ inputs.workspace_name }}

--- a/.github/workflows/create-endpoint.yml
+++ b/.github/workflows/create-endpoint.yml
@@ -38,7 +38,7 @@ jobs:
         run: az extension update -n ml
       - name: create-environment-from-file
         run: |
-          EP=$(az ml ${{ inputs.endpoint_type }}-endpoint list --query "[?name==${{ inputs.endpoint_name }}]"  -o tsv --resource-group ${{ inputs.resource_group }} --workspace-name ${{ inputs.workspace_name }})
+          EP=$(az ml ${{ inputs.endpoint_type }}-endpoint list --query "[?name=='${{ inputs.endpoint_name }}']"  -o tsv --resource-group ${{ inputs.resource_group }} --workspace-name ${{ inputs.workspace_name }})
           if [[ EP -ne 1 ]]; then
           echo "Endpoint not exists"
           az ml ${{ inputs.endpoint_type }}-endpoint create --name ${{ inputs.endpoint_name }} -f ${{ github.workspace }}/${{ inputs.endpoint_file }} --resource-group ${{ inputs.resource_group }} --workspace-name ${{ inputs.workspace_name }} 

--- a/.github/workflows/create-endpoint.yml
+++ b/.github/workflows/create-endpoint.yml
@@ -38,6 +38,17 @@ jobs:
         run: az extension update -n ml
       - name: create-environment-from-file
         run: |
-          az ml ${{ inputs.endpoint_type }}-endpoint create --name ${{ inputs.endpoint_name }} \
-          -f ${{ github.workspace }}/${{ inputs.endpoint_file }} --resource-group ${{ inputs.resource_group }} \
-          --workspace-name ${{ inputs.workspace_name }}
+          ENDPOINT_EXISTS=$(az ml ${{ inputs.endpoint_type}}-endpoint list -o tsv --query "[?name==${{ inputs.endpoint_name}}][name]" | wc -l)
+          echo $ENDPOINT_NAME $ENDPOINT_EXISTS
+          az ml ${{ inputs.endpoint_type}}-endpoint list -o tsv
+
+          if [[ ENDPOINT_EXISTS -ne 1 ]]; then
+          az ml ${{ inputs.endpoint_type}}-endpoint create --name ${{ inputs.endpoint_name}} -f ${{ inputs.endpoint_file }}
+          else
+          echo "Endpoint exists"
+          fi
+      # - name: create-environment-from-file
+      #   run: |
+      #     az ml ${{ inputs.endpoint_type }}-endpoint create --name ${{ inputs.endpoint_name }} \
+      #     -f ${{ github.workspace }}/${{ inputs.endpoint_file }} --resource-group ${{ inputs.resource_group }} \
+      #     --workspace-name ${{ inputs.workspace_name }}

--- a/.github/workflows/create-endpoint.yml
+++ b/.github/workflows/create-endpoint.yml
@@ -39,6 +39,7 @@ jobs:
       - name: create-environment-from-file
         run: |
           EP=$(az ml ${{ inputs.endpoint_type }}-endpoint list --query "[?name=='${{ inputs.endpoint_name }}']"  -o tsv --resource-group ${{ inputs.resource_group }} --workspace-name ${{ inputs.workspace_name }})
+          echo "::add-mask::$EP"
           if [[ EP -ne 1 ]]; then
           echo "Endpoint not exists"
           az ml ${{ inputs.endpoint_type }}-endpoint create --name ${{ inputs.endpoint_name }} -f ${{ github.workspace }}/${{ inputs.endpoint_file }} --resource-group ${{ inputs.resource_group }} --workspace-name ${{ inputs.workspace_name }} 


### PR DESCRIPTION
Create a step in the script that checks if an endpoint with the same name already exists before trying to create it. If the endpoint already exists, skip the creation step and print "Endpoint exists".