### PR TITLE
feat: expose networking/flags/sku/tag outputs from read-yaml

### DIFF
--- a/.github/workflows/read-yaml.yml
+++ b/.github/workflows/read-yaml.yml
@@ -58,6 +58,33 @@ on:
       terraform_st_key:
         description: "Terraform State Key"
         value: ${{ jobs.read-yaml.outputs.terraform_st_key }}
+      enable_vnet:
+        description: "Enable VNet + private endpoints"
+        value: ${{ jobs.read-yaml.outputs.enable_vnet }}
+      vnet_address_prefix:
+        description: "VNet address prefix"
+        value: ${{ jobs.read-yaml.outputs.vnet_address_prefix }}
+      default_subnet_prefix:
+        description: "Default subnet prefix"
+        value: ${{ jobs.read-yaml.outputs.default_subnet_prefix }}
+      compute_subnet_prefix:
+        description: "Compute subnet prefix"
+        value: ${{ jobs.read-yaml.outputs.compute_subnet_prefix }}
+      pe_subnet_prefix:
+        description: "Private-endpoints subnet prefix"
+        value: ${{ jobs.read-yaml.outputs.pe_subnet_prefix }}
+      enable_container_registry:
+        description: "Enable Azure Container Registry"
+        value: ${{ jobs.read-yaml.outputs.enable_container_registry }}
+      aml_compute_sku:
+        description: "AML compute cluster VM SKU"
+        value: ${{ jobs.read-yaml.outputs.aml_compute_sku }}
+      tag_cost_center:
+        description: "CostCenter tag value"
+        value: ${{ jobs.read-yaml.outputs.tag_cost_center }}
+      tag_managed_by:
+        description: "ManagedBy tag value"
+        value: ${{ jobs.read-yaml.outputs.tag_managed_by }}
 jobs:
   read-yaml:
     runs-on: ubuntu-latest
@@ -79,6 +106,15 @@ jobs:
       terraform_st_storage_account: ${{  steps.read_action_js.outputs.terraform_st_storage_account }}
       terraform_st_container_name: ${{  steps.read_action_js.outputs.terraform_st_container_name }}
       terraform_st_key: ${{  steps.read_action_js.outputs.terraform_st_key }}
+      enable_vnet: ${{  steps.read_action_js.outputs.enable_vnet }}
+      vnet_address_prefix: ${{  steps.read_action_js.outputs.vnet_address_prefix }}
+      default_subnet_prefix: ${{  steps.read_action_js.outputs.default_subnet_prefix }}
+      compute_subnet_prefix: ${{  steps.read_action_js.outputs.compute_subnet_prefix }}
+      pe_subnet_prefix: ${{  steps.read_action_js.outputs.pe_subnet_prefix }}
+      enable_container_registry: ${{  steps.read_action_js.outputs.enable_container_registry }}
+      aml_compute_sku: ${{  steps.read_action_js.outputs.aml_compute_sku }}
+      tag_cost_center: ${{  steps.read_action_js.outputs.tag_cost_center }}
+      tag_managed_by: ${{  steps.read_action_js.outputs.tag_managed_by }}
     steps:
       - name: Checking out calling repo
         uses: actions/checkout@v4

--- a/read_yaml_action/action.yml
+++ b/read_yaml_action/action.yml
@@ -40,6 +40,24 @@ outputs:
     description: "Terraform State Container name"
   terraform_st_key:
     description: 'Terraform State Key'
+  enable_vnet:
+    description: 'Boolean to enable VNet + private endpoints (network isolation)'
+  vnet_address_prefix:
+    description: 'Address prefix for the virtual network'
+  default_subnet_prefix:
+    description: 'Address prefix for the default subnet'
+  compute_subnet_prefix:
+    description: 'Address prefix for the AML compute subnet'
+  pe_subnet_prefix:
+    description: 'Address prefix for the private-endpoints subnet'
+  enable_container_registry:
+    description: 'Boolean to decide whether to deploy an Azure Container Registry'
+  aml_compute_sku:
+    description: 'VM SKU for the AML compute cluster'
+  tag_cost_center:
+    description: 'CostCenter tag value'
+  tag_managed_by:
+    description: 'ManagedBy tag value'
 runs:
   using: 'node16'
   main: 'index.js'

--- a/read_yaml_action/index.js
+++ b/read_yaml_action/index.js
@@ -33,6 +33,19 @@ try {
     var terraform_st_container_name = String(configYaml["variables"]["terraform_st_container_name"]);
     var terraform_st_key = String(configYaml["variables"]["terraform_st_key"]);
 
+    // Networking, feature-flag, compute and tag variables (optional; sensible
+    // defaults when absent so older config files keep working). Values are kept
+    // as strings to preserve the config value (FAILSAFE_SCHEMA yields strings).
+    var enable_vnet = valueOrDefault(configYaml["variables"]["enable_vnet"], "false");
+    var vnet_address_prefix = valueOrDefault(configYaml["variables"]["vnet_address_prefix"], "10.0.0.0/16");
+    var default_subnet_prefix = valueOrDefault(configYaml["variables"]["default_subnet_prefix"], "10.0.0.0/24");
+    var compute_subnet_prefix = valueOrDefault(configYaml["variables"]["compute_subnet_prefix"], "10.0.1.0/24");
+    var pe_subnet_prefix = valueOrDefault(configYaml["variables"]["pe_subnet_prefix"], "10.0.2.0/24");
+    var enable_container_registry = valueOrDefault(configYaml["variables"]["enable_container_registry"], "true");
+    var aml_compute_sku = valueOrDefault(configYaml["variables"]["aml_compute_sku"], "Standard_DS3_v2");
+    var tag_cost_center = valueOrDefault(configYaml["variables"]["tag_cost_center"], "");
+    var tag_managed_by = valueOrDefault(configYaml["variables"]["tag_managed_by"], "bicep");
+
     if(checkGenerateEntity(terraform_st_location)){
       terraform_st_location = location;
     }
@@ -69,6 +82,15 @@ try {
     core.setOutput("terraform_st_storage_account", terraform_st_storage_account);
     core.setOutput("terraform_st_container_name", terraform_st_container_name);
     core.setOutput("terraform_st_key", terraform_st_key);
+    core.setOutput("enable_vnet", enable_vnet);
+    core.setOutput("vnet_address_prefix", vnet_address_prefix);
+    core.setOutput("default_subnet_prefix", default_subnet_prefix);
+    core.setOutput("compute_subnet_prefix", compute_subnet_prefix);
+    core.setOutput("pe_subnet_prefix", pe_subnet_prefix);
+    core.setOutput("enable_container_registry", enable_container_registry);
+    core.setOutput("aml_compute_sku", aml_compute_sku);
+    core.setOutput("tag_cost_center", tag_cost_center);
+    core.setOutput("tag_managed_by", tag_managed_by);
   });
   
 } catch (error) {
@@ -81,4 +103,10 @@ function checkGenerateEntity(entity){
         result = true;
     }
     return result;
+}
+function valueOrDefault(value, fallback){
+    if (value === undefined || value === null || String(value).trim() === ""){
+        return fallback;
+    }
+    return String(value);
 }

--- a/templates/infra/run-terraform-apply.yml
+++ b/templates/infra/run-terraform-apply.yml
@@ -8,5 +8,5 @@ steps:
       provider: 'azurerm'
       command: 'apply'
       workingDirectory: '$(System.DefaultWorkingDirectory)/$(terraform_workingdir)'
-      commandOptions: '-var "location=$(location)" -var "prefix=$(namespace)" -var "postfix=$(postfix)" -var "environment=$(environment)" -var "enable_aml_computecluster=$(enable_aml_computecluster)" -var "enable_monitoring=$(enable_monitoring)" -var "client_secret=$(CLIENT_SECRET)"'
+      commandOptions: '-var "location=$(location)" -var "prefix=$(namespace)" -var "postfix=$(postfix)" -var "environment=$(environment)" -var "enable_aml_computecluster=$(enable_aml_computecluster)" -var "enable_monitoring=$(enable_monitoring)" -var "enable_private_endpoints=$(enable_vnet)" -var "vnet_address_space=$(vnet_address_prefix)" -var "training_subnet_address_prefix=$(compute_subnet_prefix)" -var "endpoints_subnet_address_prefix=$(pe_subnet_prefix)" -var "client_secret=$(CLIENT_SECRET)"'
       environmentServiceNameAzureRM: '$(ado_service_connection_rg)'

--- a/templates/infra/run-terraform-plan.yml
+++ b/templates/infra/run-terraform-plan.yml
@@ -8,5 +8,5 @@ steps:
       provider: 'azurerm'
       command: 'plan'
       workingDirectory: '$(System.DefaultWorkingDirectory)/$(terraform_workingdir)'
-      commandOptions: '-var "location=$(location)" -var "prefix=$(namespace)" -var "postfix=$(postfix)" -var "environment=$(environment)" -var "enable_aml_computecluster=$(enable_aml_computecluster)" -var "enable_monitoring=$(enable_monitoring)" -var "client_secret=$(CLIENT_SECRET)"'
+      commandOptions: '-var "location=$(location)" -var "prefix=$(namespace)" -var "postfix=$(postfix)" -var "environment=$(environment)" -var "enable_aml_computecluster=$(enable_aml_computecluster)" -var "enable_monitoring=$(enable_monitoring)" -var "enable_private_endpoints=$(enable_vnet)" -var "vnet_address_space=$(vnet_address_prefix)" -var "training_subnet_address_prefix=$(compute_subnet_prefix)" -var "endpoints_subnet_address_prefix=$(pe_subnet_prefix)" -var "client_secret=$(CLIENT_SECRET)"'
       environmentServiceNameAzureRM: '$(ado_service_connection_rg)'


### PR DESCRIPTION
The GHA deploy workflows read pipeline config through the `read-yaml` reusable workflow, which only exposed a fixed subset of config keys. To let the Bicep and Terraform GitHub Actions pipelines pass the networking / feature-flag parameters (matching the Azure DevOps pipelines), this exposes additional keys:

`enable_vnet`, `vnet_address_prefix`, `default_subnet_prefix`, `compute_subnet_prefix`, `pe_subnet_prefix`, `enable_container_registry`, `aml_compute_sku`, `tag_cost_center`, `tag_managed_by`

**Backwards compatible** — all new outputs are optional with sensible defaults in `read_yaml_action/index.js`, so existing config files keep working unchanged.

Changes:
- `read_yaml_action/index.js` — read the new keys (string values, defaulted when absent)
- `read_yaml_action/action.yml` — declare the new outputs
- `.github/workflows/read-yaml.yml` — expose them at the `workflow_call` and job levels

This unblocks wiring VNet/private-endpoint parameters through the GitHub Actions deploy pipelines in `mlops-project-template`.